### PR TITLE
docs: change URLs to GitHub

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ For a detailed documentation on the langue itself, see the language docs: [RSPL]
 
 This project provides both a CLI, and an interactive Web-App which can transpile code in real-time.
 
-A hosted version of the web-app is available at: [https://mbeboek.gitlab.io/rspl/](https://hailtododongo.github.io/rspl/) <br/>
+A hosted version of the web-app is available at: [https://hailtododongo.github.io/rspl/](https://hailtododongo.github.io/rspl/) <br/>
 
 The CLI is currently not available as a pre-build, and needs to be build from sources.<br/>
 See the build section for more information.

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -46,7 +46,7 @@
 
     <div id="footer">
         <span>RSPL-Transpiler © Max Bebök (HailToDodongo)</span>
-        <a target="_blank" href="https://gitlab.com/mbeboek/rspl">Source-Code</a>
+        <a target="_blank" href="https://github.com/HailToDodongo/rspl">Source-Code</a>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Noticed that there were 2 old GitLab URLs when checking out the web app.  grep'd the repo, these are the last 2.